### PR TITLE
Fix SCP:5K muzzle attachment not visible for AK74.

### DIFF
--- a/lua/weapons/arc9_stalker2_ar_ak74/shared.lua
+++ b/lua/weapons/arc9_stalker2_ar_ak74/shared.lua
@@ -418,7 +418,7 @@ SWEP.Attachments = {
 	{
         PrintName = "Muzzle",
 		Bone = "jnt_offset",
-        Category = {"muzzle_scp5k", "muzzle", "cod2019_muzzle" },
+        Category = {"scp5k_muzzle", "muzzle", "cod2019_muzzle" },
 		Pos = Vector(24, 0, 2),
         Ang = Angle(-0, 0, -0),
         Icon_Offset = Vector(0, 0, 0),


### PR DESCRIPTION
Changing muzzle_scp5k to scp5k_muzzle in muzzle category so SCP:5K muzzle attachment is now visible for AK74.