### PR TITLE
Making sure SCP:5k muzzles visible for TAR-21.

### DIFF
--- a/lua/weapons/arc9_stalker2_ar_tar21/shared.lua
+++ b/lua/weapons/arc9_stalker2_ar_tar21/shared.lua
@@ -398,7 +398,7 @@ SWEP.Attachments = {
 	{
         PrintName = "Muzzle",
 		Bone = "jnt_offset",
-        Category = {"muzzle_scp5k", "muzzle", "cod2019_muzzle" },
+        Category = {"scp5k_muzzle", "muzzle", "cod2019_muzzle" },
 		Pos = Vector(24, 0, 2),
         Ang = Angle(-0, 0, -0),
         Icon_Offset = Vector(0, 0, 0),


### PR DESCRIPTION
Rewriting muzzle_scp5k to scp5k_muzzle so SCP:5K muzzles can be used on TAR-21.